### PR TITLE
Remove turbolinks and gretel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 #Devise for auth
 gem 'devise'
-#Turbolinks
-gem 'turbolinks'
-#Breadcrumbs
-gem "gretel"
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
 #Front end sources

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,8 +69,6 @@ GEM
     ffi (1.9.18-x64-mingw32)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    gretel (3.0.9)
-      rails (>= 3.1.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     listen (3.1.5)
@@ -193,9 +191,6 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.3)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.3)
@@ -222,7 +217,6 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
-  gretel
   listen
   pg (~> 0.18)
   pry
@@ -236,7 +230,6 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
-  turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbolinks
 //= require_tree .


### PR DESCRIPTION
Turbolinks is trash, and we can put gretel back in later if we want
breadcrumbs.